### PR TITLE
update Cmdliner dependency to allow version 2.0.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,8 +23,7 @@
  (description "Passage - used to store and manage access to shared secrets")
  (depends
   bos
-  (cmdliner
-   (< 2.0.0))
+  cmdliner
   (ocaml
    (>= 4.14))
   conf-age

--- a/passage.opam
+++ b/passage.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ahrefs/passage"
 bug-reports: "https://github.com/ahrefs/passage/issues"
 depends: [
   "bos"
-  "cmdliner" {< "2.0.0"}
+  "cmdliner"
   "ocaml" {>= "4.14"}
   "conf-age"
   "dune" {>= "3.9"}

--- a/tests/cat_command.t
+++ b/tests/cat_command.t
@@ -93,44 +93,23 @@ Should fail - line number that does not correspond to any text
   [1]
 
 Should fail - passing invalid number to -q and -c
-  $ passage cat -q -lnot_a_number test_secret
-  passage: option '-l': invalid value 'not_a_number', expected an integer
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat -q -lnot_a_number test_secret > /dev/null 2>&1
   [124]
-  $ passage cat -c -lnot_a_number test_secret
-  passage: option '-l': invalid value 'not_a_number', expected an integer
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat -c -lnot_a_number test_secret > /dev/null 2>&1
   [124]
 
 Should fail - passing in both -c and -q flags
-  $ passage cat -c -q test_secret
-  passage: options '-q' and '-c' cannot be present at the same time
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat -c -q test_secret > /dev/null 2>&1
   [124]
 
 Should fail - passing in invalid secret names
-  $ passage cat ..
-  passage: SECRET_NAME argument: .. is not a valid secret
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat .. > /dev/null 2>&1
   [124]
-  $ passage cat ../
-  passage: SECRET_NAME argument: ../ is not a valid secret
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat ../ > /dev/null 2>&1
   [124]
-  $ passage cat /..
-  passage: SECRET_NAME argument: /.. is not a valid secret
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat /.. > /dev/null 2>&1
   [124]
-  $ passage cat /../
-  passage: SECRET_NAME argument: /../ is not a valid secret
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat /../ > /dev/null 2>&1
   [124]
   $ passage cat /../test_secret
   
@@ -139,10 +118,7 @@ Should fail - passing in invalid secret names
   secret line 2
   secret line 3\123\65
 
-  $ passage cat test_secret/..
-  passage: SECRET_NAME argument: test_secret/.. is not a valid secret
-  Usage: passage cat [--clip] [--line=LINE] [--qrcode] [OPTION]… SECRET_NAME
-  Try 'passage cat --help' or 'passage --help' for more information.
+  $ passage cat test_secret/.. > /dev/null 2>&1
   [124]
   $ passage cat 01/../00
   E: 00 is a directory

--- a/tests/search_command.t
+++ b/tests/search_command.t
@@ -33,13 +33,7 @@ Regex specified as pattern  - should list all multiline secrets
   I: skipped 4 secrets, failed to search 0 secrets and matched 3 secrets
 
 Invalid regex specified as pattern
-  $ passage search "["
-  passage: PATTERN argument: missing ]: [
-  Usage: passage search [--verbose] [OPTION]… PATTERN [PATH]
-  Try 'passage search --help' or 'passage --help' for more information.
+  $ passage search "[" > /dev/null 2>&1
   [124]
-  $ passage search "**"
-  passage: PATTERN argument: no argument for repetition operator: *
-  Usage: passage search [--verbose] [OPTION]… PATTERN [PATH]
-  Try 'passage search --help' or 'passage --help' for more information.
+  $ passage search "**" > /dev/null 2>&1
   [124]


### PR DESCRIPTION
The code compile fine and almost all test pass with cmdline 2.*. The only issue was that cram tests, testing the failure of parsing argument, were capturing the full error message that changed with cmdline 2.0. Now, only the return error code is check, making the test robust to change of the error message.