### PR TITLE
Fix deadlock in `Age.encrypt_string...`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix a deadlock in `encrypt_string` ([#25](https://github.com/ahrefs/passage/pull/25))
+
 ## 0.3.5 (2026-04-02)
 
 - Fix missing --version number.

--- a/lib/age.ml
+++ b/lib/age.ml
@@ -22,12 +22,12 @@ let decrypt_string ?use_sudo ~identity_file ~silence_stderr ciphertext =
   let raw_command = Printf.sprintf "age --decrypt --identity %s" (Filename.quote identity_file) in
   Shell.run_cmd ~stdin ~silence_stderr ~stdout ?use_sudo raw_command
 
-let encrypt_string ?use_sudo ~recipients plaintext =
+let encrypt_string_to_file ?use_sudo ~recipients ~path plaintext =
   let stdin = Bos.OS.Cmd.in_string plaintext in
-  let stdout = Bos.OS.Cmd.out_string in
+  let stdout = Bos.OS.Cmd.out_null in
   let recipient_keys = get_recipients_keys recipients |> Key.project_list |> List.sort_uniq String.compare in
   let recipients_arg =
     List.map (fun key -> Printf.sprintf "--recipient %s" (Filename.quote key)) recipient_keys |> String.concat " "
   in
-  let raw_command = Printf.sprintf "age --encrypt --armor %s" recipients_arg in
+  let raw_command = Printf.sprintf "age --encrypt --armor %s --output %s" recipients_arg (Filename.quote path) in
   Shell.run_cmd ~stdin ~stdout ?use_sudo raw_command

--- a/lib/age.mli
+++ b/lib/age.mli
@@ -16,4 +16,8 @@ val recipient_compare : recipient -> recipient -> int
 val is_group_recipient : string -> bool
 val get_recipients_keys : recipient list -> Key.t list
 val decrypt_string : ?use_sudo:bool -> identity_file:string -> silence_stderr:bool -> string -> string
-val encrypt_string : ?use_sudo:bool -> recipients:recipient list -> string -> string
+
+(** Encrypt string for [recipients] using age and write to [path].
+
+    If [use_sudo] is true, the call to [age] is done through [sudo]. *)
+val encrypt_string_to_file : ?use_sudo:bool -> recipients:recipient list -> path:string -> string -> unit

--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -249,8 +249,15 @@ module Secrets = struct
   *)
   let encrypt_using_tmpfile ~secret_name ~plaintext ?use_sudo recipients =
     let secret_file = Path.(agefile_of_name secret_name |> abs |> project) in
-    let encrypted_content = Age.encrypt_string ?use_sudo ~recipients plaintext in
-    save_as ~path:secret_file @@ fun oc -> output_string oc encrypted_content
+    let temp = Printf.sprintf "%s.save.%d.tmp" secret_file (Unix.getpid ()) in
+    Fun.protect ~finally:(fun () ->
+      if Sys.file_exists temp then (
+        Printf.eprintf "Encryption failed, purging temp file: %s\n" temp;
+        Unix.unlink temp))
+    @@ fun () ->
+    Age.encrypt_string_to_file ?use_sudo ~recipients ~path:temp plaintext;
+    Unix.chmod temp 0o644;
+    Unix.rename temp secret_file
 
   let encrypt_exn ?use_sudo ?(verbose = false) ~plaintext ~secret_name recipients =
     verbose_eprintlf ~verbose "I: encrypting %s for %s" (Secret_name.project secret_name)

--- a/tests/create_command_failure.t
+++ b/tests/create_command_failure.t
@@ -1,0 +1,20 @@
+  $ . ./setup_fixtures.sh
+
+Verify that no temp files are left if age fails to encrypt a secret.
+
+  $ mkdir -p bin
+  $ AGE=$(which age)
+  $ cat<<EOF > bin/age
+  > #!/bin/sh
+  > if [ "\$1" = "--encrypt" ]; then false; else exec $AGE "\$@"; fi
+  > EOF
+  $ chmod u+x bin/age
+  $ export PATH="$(pwd)/bin:$PATH"
+  $ echo "contents" | passage create 00/secret 2>&1 | sed 's/--recipient.*/.../g'
+  E: encrypting 00/secret failed: Failure("age --encrypt --armor ...
+  $ ls -a $PASSAGE_DIR/secrets/00
+  .
+  ..
+  .keys
+  .secret_starting_with_dot.age
+  secret1.age


### PR DESCRIPTION
# What

Fix a deadlock in `Age.encrypt_string`. The deadlock would present itself when running the test suite with `-j > 1`. I think the underlying issue is in `bos`: https://github.com/dbuenzli/bos/issues/105
It's quite easy to replicate the hang on my system with:
```
while true; do dune clean; dune runtest; done
```
it eventually hangs. More on debugging this problem in the bos issue linked above.

A simple fix is to avoid writing to stdin while at the same time reading stdout of `age`. Since we write encrypted secrets to a file anyhow, we delegate this to the age binary.

# Todo

- [x] Test more. 
- [ ] Test sudo.
- [x] Write doc strings