### PR TITLE
[Storage.save_as] do not clobber non-regular files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix a deadlock in `encrypt_string` ([#25](https://github.com/ahrefs/passage/pull/25))
+- Fix clobbering of special files in `Storage.save_as` ([#28](https://github.com/ahrefs/passage/pull/28))
 
 ## 0.3.5 (2026-04-02)
 

--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -19,7 +19,7 @@ let config_lines filename =
         | "" -> None
         | s -> Some s))
 
-let save_as ?(mode = 0o644) ~path f =
+let save_as_regular ?(mode = 0o644) ~path f =
   let temp = Printf.sprintf "%s.save.%d.tmp" path (Unix.getpid ()) in
   let fd = Unix.openfile temp [ Unix.O_WRONLY; Unix.O_CREAT ] mode in
   Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
@@ -32,6 +32,16 @@ let save_as ?(mode = 0o644) ~path f =
   with exn ->
     (try Unix.unlink temp with _ -> ());
     raise exn
+
+let save_as ?mode ~path f =
+  let path =
+    match (Unix.lstat path).st_kind with
+    | Unix.S_LNK -> Unix.realpath path
+    | (exception Unix.Unix_error (Unix.ENOENT, _, _)) | _ -> path
+  in
+  match (Unix.stat path).st_kind with
+  | Unix.S_REG | (exception Unix.Unix_error (Unix.ENOENT, _, _)) -> save_as_regular ?mode ~path f
+  | _ -> Out_channel.with_open_gen [ Open_wronly ] 0 path f
 
 module Secret_name = struct
   include Types.Fresh (String)

--- a/lib/storage.mli
+++ b/lib/storage.mli
@@ -5,9 +5,11 @@ val config_lines : string -> string list
 
 (** File output protected with atomic rename.
 
-    [save_as path f] is similar to {!Out_channel.with_open_bin} except that writing is done to a temporary file that
-    will be renamed to [path] after [f] has successfully terminated. This guarantees that either [path] is not modified
-    or contains whatever [f] wrote to it.
+    [save_as path f] is similar to {!Out_channel.with_open_bin} for regular files, except that writing is done to a
+    temporary file that will be renamed to [path]'s absolute path (resolved as per {!Unix.realpath}) after [f] has
+    successfully terminated. This guarantees that either [path] is not modified or contains whatever [f] wrote to it.
+
+    There is no such special treatment for special files, instead they are written to directly.
 
     Mode, if absent, defaults to [0o644].
 

--- a/tests/dune
+++ b/tests/dune
@@ -2,3 +2,7 @@
  (deps
   (file setup_fixtures.sh)
   %{bin:passage}))
+
+(test
+ (name test_save_as)
+ (libraries passage unix threads.posix))

--- a/tests/test_save_as.ml
+++ b/tests/test_save_as.ml
@@ -1,0 +1,84 @@
+let () =
+  let failures = ref 0 in
+  let test name f =
+    Printf.printf "test %s: " name;
+    match f () with
+    | () -> Printf.printf "ok\n"
+    | exception exn ->
+      incr failures;
+      Printf.printf "FAIL: %s\n" (Printexc.to_string exn)
+  in
+  let tmpdir = Filename.get_temp_dir_name () in
+
+  test "writes to new regular file" (fun () ->
+    let path = Filename.concat tmpdir "test_save_as_new.txt" in
+    Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ()) @@ fun () ->
+    Passage.Storage.save_as ~path (fun oc -> output_string oc "hello\n");
+    let content = In_channel.with_open_text path In_channel.input_all in
+    assert (content = "hello\n"));
+
+  test "overwrites existing regular file" (fun () ->
+    let path = Filename.concat tmpdir "test_save_as_overwrite.txt" in
+    Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ()) @@ fun () ->
+    Out_channel.with_open_text path (fun oc -> output_string oc "old\n");
+    Passage.Storage.save_as ~path (fun oc -> output_string oc "new\n");
+    let content = In_channel.with_open_text path In_channel.input_all in
+    assert (content = "new\n"));
+
+  test "no temp file left on success" (fun () ->
+    let path = Filename.concat tmpdir "test_save_as_no_temp.txt" in
+    Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ()) @@ fun () ->
+    Passage.Storage.save_as ~path (fun oc -> output_string oc "data\n");
+    let temp = Printf.sprintf "%s.save.%d.tmp" path (Unix.getpid ()) in
+    assert (not (Sys.file_exists temp)));
+
+  test "no temp file left on failure" (fun () ->
+    let path = Filename.concat tmpdir "test_save_as_fail.txt" in
+    (try Passage.Storage.save_as ~path (fun _oc -> failwith "boom") with Failure _ -> ());
+    let temp = Printf.sprintf "%s.save.%d.tmp" path (Unix.getpid ()) in
+    assert (not (Sys.file_exists temp));
+    assert (not (Sys.file_exists path)));
+
+  test "writes to /dev/null without error" (fun () ->
+    Passage.Storage.save_as ~path:"/dev/null" (fun oc -> output_string oc "discarded\n");
+    let temp = Printf.sprintf "/dev/null.save.%d.tmp" (Unix.getpid ()) in
+    assert (not (Sys.file_exists temp));
+    assert ((Unix.stat "/dev/null").st_kind = Unix.S_CHR));
+
+  test "writes to named pipe (FIFO)" (fun () ->
+    let fifo_path = Filename.concat tmpdir "test_save_as_fifo" in
+    (try Sys.remove fifo_path with _ -> ());
+    Fun.protect ~finally:(fun () -> try Sys.remove fifo_path with _ -> ()) @@ fun () ->
+    Unix.mkfifo fifo_path 0o644;
+    let received = ref "" in
+    let reader = Thread.create (fun () -> received := In_channel.with_open_text fifo_path In_channel.input_all) () in
+    Passage.Storage.save_as ~path:fifo_path (fun oc -> output_string oc "fifo data\n");
+    Thread.join reader;
+    assert (!received = "fifo data\n"));
+
+  test "no temp file created for FIFO" (fun () ->
+    let fifo_path = Filename.concat tmpdir "test_save_as_fifo2" in
+    (try Sys.remove fifo_path with _ -> ());
+    Fun.protect ~finally:(fun () -> try Sys.remove fifo_path with _ -> ()) @@ fun () ->
+    Unix.mkfifo fifo_path 0o644;
+    let reader = Thread.create (fun () -> ignore (In_channel.with_open_text fifo_path In_channel.input_all)) () in
+    Passage.Storage.save_as ~path:fifo_path (fun oc -> output_string oc "data\n");
+    Thread.join reader;
+    let temp = Printf.sprintf "%s.save.%d.tmp" fifo_path (Unix.getpid ()) in
+    assert (not (Sys.file_exists temp)));
+
+  test "writes through symlink without clobbering it" (fun () ->
+    let target = Filename.concat tmpdir "test_save_as_symlink_target.txt" in
+    let link = Filename.concat tmpdir "test_save_as_symlink_link.txt" in
+    Fun.protect ~finally:(fun () ->
+      (try Sys.remove target with _ -> ());
+      try Sys.remove link with _ -> ())
+    @@ fun () ->
+    Out_channel.with_open_text target (fun oc -> output_string oc "old\n");
+    Unix.symlink target link;
+    Passage.Storage.save_as ~path:link (fun oc -> output_string oc "new\n");
+    assert ((Unix.lstat link).st_kind = Unix.S_LNK);
+    let content = In_channel.with_open_text target In_channel.input_all in
+    assert (content = "new\n"));
+
+  if !failures > 0 then exit 1


### PR DESCRIPTION
`Storage.save_as` checks whether the target file is regular before attempting the "write to temp, rename temp to file" procedure. If regular, just write directly to the file.