### PR TITLE
consistent interface to who/add-who/rm-who/edit-who

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -185,13 +185,12 @@ end
 
 module Edit_who = struct
   let edit_who_with_check secret_name =
-    let secret_path = Storage.Secrets.(to_path secret_name) in
-    match Path.is_directory (Path.abs secret_path), Storage.Secrets.secret_exists_at secret_path with
-    | false, false -> Shell.die "E: no such secret: %s" (show_name secret_name)
-    | _ ->
-      let path = Storage.Secrets.(to_path secret_name) in
-      (try Invariant.run_if_recipient ~op_string:"edit recipients" ~path ~f:(fun () -> edit_recipients secret_name)
-       with Failure s -> Shell.die "%s" s)
+    Commands.Recipients.check_path_with_recipients secret_name;
+    let secret_path = Named_path.path secret_name in
+    try
+      Invariant.run_if_recipient ~op_string:"edit recipients" ~path:secret_path ~f:(fun () ->
+        edit_recipients (Named_path.to_secret_name secret_name))
+    with Failure s -> Shell.die "%s" s
 
   let edit_who =
     let doc =
@@ -199,7 +198,7 @@ module Edit_who = struct
       \  in the tree, so all recipients need to be specified at the level of the immediately containing folder."
     in
     let info = Cmd.info "edit-who" ~doc in
-    let term = Term.(const edit_who_with_check $ Flags.secret_name) in
+    let term = Term.(const edit_who_with_check $ Flags.named_secret_path) in
     Cmd.v info term
 end
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -793,11 +793,26 @@ module Who = struct
   let who =
     let doc = "list all recipients of secrets in the specified path" in
     let info = Cmd.info "who" ~doc in
+    let recipient_spec_arg =
+      let parse str =
+        if Age.is_group_recipient str then Ok (Commands.Recipients.Group str)
+        else (try Ok (Commands.Recipients.Path (Path.build_rel_path str)) with Failure s -> Error (`Msg s))
+      in
+      let print ppf = function
+        | Commands.Recipients.Group group -> Format.fprintf ppf "%s" group
+        | Commands.Recipients.Path path -> Format.fprintf ppf "%s" (show_path path)
+      in
+      Arg.conv (parse, print)
+    in
+    let recipient_spec =
+      let doc = "the relative $(docv) from the secrets directory that will be used to process secrets" in
+      Arg.(value & pos 0 recipient_spec_arg (Commands.Recipients.Path (Path.inject ".")) & info [] ~docv:"PATH" ~doc)
+    in
     let term =
       Term.(
         const (fun secrets_path expand_groups ->
           try Commands.Recipients.list_recipients secrets_path expand_groups with Failure s -> Shell.die "%s" s)
-        $ Flags.secrets_path
+        $ recipient_spec
         $ expand_groups)
     in
     Cmd.v info term

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -24,6 +24,11 @@ module Converters = struct
     let print ppf p = Format.fprintf ppf "%s" (show_path p) in
     Arg.conv (parse, print)
 
+  let named_path_arg =
+    let parse name = try Ok (Named_path.of_string name) with Failure s -> Error (`Msg s) in
+    let print = Named_path.pp in
+    Arg.conv (parse, print)
+
   let template_arg =
     let parse template = try Ok (Template.parse template) with Failure s -> Error (`Msg s) in
     let print ppf p = Format.fprintf ppf "%s" (Template.dump p) in
@@ -79,6 +84,10 @@ module Flags = struct
     in
     Arg.(value & pos_all string [ "." ] & info [] ~docv:"PATH" ~doc)
 
+  let named_secret_path =
+    let doc = "the relative $(docv) from the secrets directory that will be used to process secrets" in
+    Arg.(value & pos 0 Converters.named_path_arg (Named_path.of_string ".") & info [] ~docv:"PATH" ~doc)
+
   let verbose =
     let doc = "print verbose output during execution" in
     Arg.(value & flag & info [ "v"; "verbose" ] ~doc)
@@ -105,7 +114,7 @@ module Add_who = struct
         const (fun secret_name recipients_to_add ->
           try Commands.Recipients.add_recipients_to_secret secret_name recipients_to_add
           with Failure s -> Shell.die "%s" s)
-        $ Flags.secret_name
+        $ Flags.named_secret_path
         $ recipient_names)
     in
     Cmd.v info term
@@ -124,7 +133,7 @@ module Rm_who = struct
         const (fun secret_name recipients_to_remove ->
           try Commands.Recipients.remove_recipients_from_secret secret_name recipients_to_remove
           with Failure s -> Shell.die "%s" s)
-        $ Flags.secret_name
+        $ Flags.named_secret_path
         $ recipient_names)
     in
     Cmd.v info term
@@ -796,17 +805,17 @@ module Who = struct
     let recipient_spec_arg =
       let parse str =
         if Age.is_group_recipient str then Ok (Commands.Recipients.Group str)
-        else (try Ok (Commands.Recipients.Path (Path.build_rel_path str)) with Failure s -> Error (`Msg s))
+        else (try Ok (Commands.Recipients.Path (Named_path.of_string str)) with Failure s -> Error (`Msg s))
       in
       let print ppf = function
         | Commands.Recipients.Group group -> Format.fprintf ppf "%s" group
-        | Commands.Recipients.Path path -> Format.fprintf ppf "%s" (show_path path)
+        | Commands.Recipients.Path path -> Named_path.pp ppf path
       in
       Arg.conv (parse, print)
     in
     let recipient_spec =
       let doc = "the relative $(docv) from the secrets directory that will be used to process secrets" in
-      Arg.(value & pos 0 recipient_spec_arg (Commands.Recipients.Path (Path.inject ".")) & info [] ~docv:"PATH" ~doc)
+      Arg.(value & pos 0 recipient_spec_arg (Commands.Recipients.Path Named_path.root) & info [] ~docv:"PATH" ~doc)
     in
     let term =
       Term.(

--- a/bin/prompt.ml
+++ b/bin/prompt.ml
@@ -201,5 +201,6 @@ let edit_recipients secret_name =
     | Ok () -> Ok recipients_list
   in
   match Editor.edit_with_validation ~initial:initial_content ~validate:validate_recipients () with
-  | Ok new_recipients_list -> Commands.Recipients.rewrite_recipients_file secret_name new_recipients_list
+  | Ok new_recipients_list ->
+    Commands.Recipients.rewrite_recipients_file (Named_path.of_secret_name secret_name) new_recipients_list
   | Error _ -> prerr_endline "E: no recipients provided"

--- a/lib/commands.ml
+++ b/lib/commands.ml
@@ -244,8 +244,11 @@ module Recipients = struct
           flush stderr)
       recipients_names
 
-  let list_recipients path expand_groups =
-    let string_path = show_path path in
+  type recipient_spec =
+    | Group of string
+    | Path of Path.t
+
+  let list_recipients recipient_spec expand_groups =
     let print_from_recipient_list recipients =
       List.iter
         (fun (r : Age.recipient) ->
@@ -255,9 +258,9 @@ module Recipients = struct
           print_endline r.name)
         recipients
     in
-    match Age.is_group_recipient string_path with
-    | true -> Storage.Secrets.recipients_of_group_name_exn string_path |> print_from_recipient_list
-    | false ->
+    match recipient_spec with
+    | Group group -> Storage.Secrets.recipients_of_group_name_exn group |> print_from_recipient_list
+    | Path path ->
     match Storage.Secrets.secret_exists_at path || Storage.Secrets.get_secrets_tree path <> [] with
     | false -> die "E: no such secret %s" (show_path path)
     | true ->

--- a/lib/commands.ml
+++ b/lib/commands.ml
@@ -132,7 +132,7 @@ module Recipients = struct
     | false -> ()
     | true ->
       (* also adds root group by default for all new secrets *)
-      let root_recipients_names = Storage.Secrets.recipients_of_group_name_exn ~map_fn:Fun.id "@root" in
+      let root_recipients_names = Storage.Secrets.expand_group_exn "@root" in
       let () = eprintfn "\nI: using recipient group @root for secret %s" (show_path secret_path) in
       (* avoid repeating names if the user creating the secret is already in the root group *)
       let recipients_names =
@@ -256,9 +256,7 @@ module Recipients = struct
         recipients
     in
     match Age.is_group_recipient string_path with
-    | true ->
-      Storage.Secrets.recipients_of_group_name_exn ~map_fn:Storage.Secrets.recipient_of_name string_path
-      |> print_from_recipient_list
+    | true -> Storage.Secrets.recipients_of_group_name_exn string_path |> print_from_recipient_list
     | false ->
     match Storage.Secrets.secret_exists_at path || Storage.Secrets.get_secrets_tree path <> [] with
     | false -> die "E: no such secret %s" (show_path path)
@@ -281,9 +279,7 @@ module Recipients = struct
             | true ->
             try
               (* we don't need the group recipients, just to know that there are some *)
-              let (_ : Age.recipient list) =
-                Storage.Secrets.recipients_of_group_name_exn ~map_fn:Storage.Secrets.recipient_of_name recipient_name
-              in
+              let (_ : Age.recipient list) = Storage.Secrets.recipients_of_group_name_exn recipient_name in
               [ Age.Key.inject "" ]
             with exn ->
               printfn "E: couldn't retrieve recipients for group %s. Reason: %s" recipient_name (Printexc.to_string exn);

--- a/lib/commands.ml
+++ b/lib/commands.ml
@@ -173,14 +173,14 @@ module Recipients = struct
       else ())
     else prerr_endline "I: no changes made to the recipients"
 
-  let check_named_path_exists_or_die secret_named_path =
+  let check_path_with_recipients secret_named_path =
     let path = Named_path.path secret_named_path in
     if (not (Storage.Secrets.secret_exists_at path)) && Storage.Secrets.get_secrets_tree path = [] then
       Exn.die "E: no such secret: %s" (Named_path.show secret_named_path)
 
   let add_recipients_to_secret ?use_sudo (secret_name : Named_path.t) recipients_to_add =
     let secret_path = secret_name.path in
-    check_named_path_exists_or_die secret_name;
+    check_path_with_recipients secret_name;
     Invariant.run_if_recipient ~op_string:"add recipients" ~path:secret_path ~f:(fun () ->
       let () =
         match Validation.validate_recipients_for_commands recipients_to_add with
@@ -198,7 +198,7 @@ module Recipients = struct
 
   let remove_recipients_from_secret ?use_sudo (secret_name : Named_path.t) recipients_to_remove =
     let secret_path = Named_path.path secret_name in
-    check_named_path_exists_or_die secret_name;
+    check_path_with_recipients secret_name;
     Invariant.run_if_recipient ~op_string:"remove recipients" ~path:secret_path ~f:(fun () ->
       let current_recipients = Storage.Secrets.get_recipients_names secret_path in
       let new_recipients = List.filter (fun r -> not (List.mem r recipients_to_remove)) current_recipients in
@@ -267,7 +267,7 @@ module Recipients = struct
     | Group group -> Storage.Secrets.recipients_of_group_name_exn group |> print_from_recipient_list
     | Path named_path ->
       let path = named_path.path in
-      check_named_path_exists_or_die named_path;
+      check_path_with_recipients named_path;
       (match expand_groups with
       | true ->
         (match Storage.Secrets.get_recipients_from_path_exn path with

--- a/lib/commands.ml
+++ b/lib/commands.ml
@@ -128,12 +128,12 @@ end
 
 module Recipients = struct
   let add_recipients_if_none_exists recipients secret_path =
-    match Storage.Secrets.no_keys_file (Path.dirname secret_path) with
+    match Storage.Secrets.no_keys_file (Path.dirname (Named_path.path secret_path)) with
     | false -> ()
     | true ->
       (* also adds root group by default for all new secrets *)
       let root_recipients_names = Storage.Secrets.expand_group_exn "@root" in
-      let () = eprintfn "\nI: using recipient group @root for secret %s" (show_path secret_path) in
+      let () = eprintfn "\nI: using recipient group @root for secret %s" (Named_path.show secret_path) in
       (* avoid repeating names if the user creating the secret is already in the root group *)
       let recipients_names =
         List.filter_map
@@ -141,19 +141,19 @@ module Recipients = struct
             match List.mem r.Age.name root_recipients_names with
             | true -> None
             | false ->
-              let () = eprintfn "I: using recipient %s for secret %s" r.name (show_path secret_path) in
+              let () = eprintfn "I: using recipient %s for secret %s" r.name (Named_path.show secret_path) in
               Some r.name)
           recipients
       in
       let () = flush stderr in
       let recipients_names_with_root_group = "@root" :: (recipients_names |> List.sort String.compare) in
-      let recipients_file_path = Storage.Secrets.get_recipients_file_path secret_path in
+      let recipients_file_path = Storage.Secrets.get_recipients_file_path (Named_path.path secret_path) in
       let (_ : Path.t) = Path.ensure_parent recipients_file_path in
       Storage.save_as ~mode:0o666 ~path:(show_path recipients_file_path) @@ fun oc ->
       List.iter (fun line -> Printf.fprintf oc "%s\n" line) recipients_names_with_root_group
 
-  let rewrite_recipients_file ?use_sudo secret_name new_recipients_list =
-    let secret_path = path_of_secret_name secret_name in
+  let rewrite_recipients_file ?use_sudo (secret_name : Named_path.t) new_recipients_list =
+    let secret_path = Named_path.path secret_name in
     let sorted_base_recipients = Storage.Secrets.get_recipients_names secret_path in
     let secret_recipients_file = Storage.Secrets.get_recipients_file_path secret_path in
     let (_ : Path.t) = Path.ensure_parent secret_recipients_file in
@@ -173,9 +173,14 @@ module Recipients = struct
       else ())
     else prerr_endline "I: no changes made to the recipients"
 
-  let add_recipients_to_secret ?use_sudo secret_name recipients_to_add =
-    let secret_path = path_of_secret_name secret_name in
-    Util.Secret.check_path_exists_or_die secret_name secret_path;
+  let check_named_path_exists_or_die secret_named_path =
+    let path = Named_path.path secret_named_path in
+    if (not (Storage.Secrets.secret_exists_at path)) && Storage.Secrets.get_secrets_tree path = [] then
+      Exn.die "E: no such secret: %s" (Named_path.show secret_named_path)
+
+  let add_recipients_to_secret ?use_sudo (secret_name : Named_path.t) recipients_to_add =
+    let secret_path = secret_name.path in
+    check_named_path_exists_or_die secret_name;
     Invariant.run_if_recipient ~op_string:"add recipients" ~path:secret_path ~f:(fun () ->
       let () =
         match Validation.validate_recipients_for_commands recipients_to_add with
@@ -191,9 +196,9 @@ module Recipients = struct
         let added_count = List.length new_recipients - List.length current_recipients in
         eprintfn "I: added %d recipient%s" added_count (if added_count = 1 then "" else "s"))
 
-  let remove_recipients_from_secret ?use_sudo secret_name recipients_to_remove =
-    let secret_path = path_of_secret_name secret_name in
-    Util.Secret.check_path_exists_or_die secret_name secret_path;
+  let remove_recipients_from_secret ?use_sudo (secret_name : Named_path.t) recipients_to_remove =
+    let secret_path = Named_path.path secret_name in
+    check_named_path_exists_or_die secret_name;
     Invariant.run_if_recipient ~op_string:"remove recipients" ~path:secret_path ~f:(fun () ->
       let current_recipients = Storage.Secrets.get_recipients_names secret_path in
       let new_recipients = List.filter (fun r -> not (List.mem r recipients_to_remove)) current_recipients in
@@ -246,7 +251,7 @@ module Recipients = struct
 
   type recipient_spec =
     | Group of string
-    | Path of Path.t
+    | Path of Named_path.t
 
   let list_recipients recipient_spec expand_groups =
     let print_from_recipient_list recipients =
@@ -260,39 +265,39 @@ module Recipients = struct
     in
     match recipient_spec with
     | Group group -> Storage.Secrets.recipients_of_group_name_exn group |> print_from_recipient_list
-    | Path path ->
-    match Storage.Secrets.secret_exists_at path || Storage.Secrets.get_secrets_tree path <> [] with
-    | false -> die "E: no such secret %s" (show_path path)
-    | true ->
-    match expand_groups with
-    | true ->
-      (match Storage.Secrets.get_recipients_from_path_exn path with
-      | exception exn -> Util.Secret.die_failed_get_recipients ~exn ""
+    | Path named_path ->
+      let path = named_path.path in
+      check_named_path_exists_or_die named_path;
+      (match expand_groups with
+      | true ->
+        (match Storage.Secrets.get_recipients_from_path_exn path with
+        | exception exn -> Util.Secret.die_failed_get_recipients ~exn ""
+        | [] -> Util.Secret.die_no_recipients_found path
+        | recipients -> print_from_recipient_list recipients)
+      | false ->
+      match Storage.Secrets.get_recipients_names path with
       | [] -> Util.Secret.die_no_recipients_found path
-      | recipients -> print_from_recipient_list recipients)
-    | false ->
-    match Storage.Secrets.get_recipients_names path with
-    | [] -> Util.Secret.die_no_recipients_found path
-    | recipients_names ->
-      List.iter
-        (fun recipient_name ->
-          let recipient_keys =
-            match Age.is_group_recipient recipient_name with
-            | false -> Storage.Keys.keys_of_recipient recipient_name
-            | true ->
-            try
-              (* we don't need the group recipients, just to know that there are some *)
-              let (_ : Age.recipient list) = Storage.Secrets.recipients_of_group_name_exn recipient_name in
-              [ Age.Key.inject "" ]
-            with exn ->
-              printfn "E: couldn't retrieve recipients for group %s. Reason: %s" recipient_name (Printexc.to_string exn);
-              []
-          in
-          (match recipient_keys with
-          | [] -> eprintfn "W: no keys found for %s" recipient_name
-          | _ -> ());
-          print_endline recipient_name)
-        recipients_names
+      | recipients_names ->
+        List.iter
+          (fun recipient_name ->
+            let recipient_keys =
+              match Age.is_group_recipient recipient_name with
+              | false -> Storage.Keys.keys_of_recipient recipient_name
+              | true ->
+              try
+                (* we don't need the group recipients, just to know that there are some *)
+                let (_ : Age.recipient list) = Storage.Secrets.recipients_of_group_name_exn recipient_name in
+                [ Age.Key.inject "" ]
+              with exn ->
+                printfn "E: couldn't retrieve recipients for group %s. Reason: %s" recipient_name
+                  (Printexc.to_string exn);
+                []
+            in
+            (match recipient_keys with
+            | [] -> eprintfn "W: no keys found for %s" recipient_name
+            | _ -> ());
+            print_endline recipient_name)
+          recipients_names)
 
   let find_overlap ?use_sudo ~limit () =
     let own_recipients = Storage.Secrets.recipients_of_own_id ?use_sudo () in
@@ -515,7 +520,7 @@ If the secret is a staging secret, its only recipient should be @everyone.
         let secret_recipients =
           if secret_recipients' = [] && self_fallback then (
             let own_recipients = Storage.Secrets.recipients_of_own_id ?use_sudo:None () in
-            let () = Recipients.add_recipients_if_none_exists own_recipients secret_path in
+            let () = Recipients.add_recipients_if_none_exists own_recipients (Named_path.of_path secret_path) in
             Storage.Secrets.get_recipients_from_path_exn secret_path)
           else secret_recipients'
         in

--- a/lib/commands.mli
+++ b/lib/commands.mli
@@ -18,16 +18,16 @@ module List_ : sig
 end
 
 module Recipients : sig
-  val add_recipients_if_none_exists : Age.recipient list -> Path.t -> unit
-  val rewrite_recipients_file : ?use_sudo:bool -> Storage.Secret_name.t -> string list -> unit
-  val add_recipients_to_secret : ?use_sudo:bool -> Storage.Secret_name.t -> string list -> unit
-  val remove_recipients_from_secret : ?use_sudo:bool -> Storage.Secret_name.t -> string list -> unit
+  val add_recipients_if_none_exists : Age.recipient list -> Named_path.t -> unit
+  val rewrite_recipients_file : ?use_sudo:bool -> Named_path.t -> string list -> unit
+  val add_recipients_to_secret : ?use_sudo:bool -> Named_path.t -> string list -> unit
+  val remove_recipients_from_secret : ?use_sudo:bool -> Named_path.t -> string list -> unit
   val list_recipient_secrets : ?use_sudo:bool -> ?verbose:bool -> string list -> unit
 
   (** A recipient_spec is either a group or a path. *)
   type recipient_spec =
     | Group of string
-    | Path of Path.t
+    | Path of Named_path.t
 
   val list_recipients : recipient_spec -> bool -> unit
   val find_overlap : ?use_sudo:bool -> limit:int -> unit -> (string * int) list * int

--- a/lib/commands.mli
+++ b/lib/commands.mli
@@ -23,7 +23,13 @@ module Recipients : sig
   val add_recipients_to_secret : ?use_sudo:bool -> Storage.Secret_name.t -> string list -> unit
   val remove_recipients_from_secret : ?use_sudo:bool -> Storage.Secret_name.t -> string list -> unit
   val list_recipient_secrets : ?use_sudo:bool -> ?verbose:bool -> string list -> unit
-  val list_recipients : Path.t -> bool -> unit
+
+  (** A recipient_spec is either a group or a path. *)
+  type recipient_spec =
+    | Group of string
+    | Path of Path.t
+
+  val list_recipients : recipient_spec -> bool -> unit
   val find_overlap : ?use_sudo:bool -> limit:int -> unit -> (string * int) list * int
 end
 

--- a/lib/commands.mli
+++ b/lib/commands.mli
@@ -18,6 +18,9 @@ module List_ : sig
 end
 
 module Recipients : sig
+  (** Check if [named_path] has an editable list of recipients, or die. *)
+  val check_path_with_recipients : Named_path.t -> unit
+
   val add_recipients_if_none_exists : Age.recipient list -> Named_path.t -> unit
   val rewrite_recipients_file : ?use_sudo:bool -> Named_path.t -> string list -> unit
   val add_recipients_to_secret : ?use_sudo:bool -> Named_path.t -> string list -> unit

--- a/lib/named_path.ml
+++ b/lib/named_path.ml
@@ -9,6 +9,8 @@ let of_string name = { name; path = Path.build_rel_path name }
 let of_secret_name secret_name = Storage.Secret_name.project secret_name |> of_string
 let of_path path = { name = Path.project path; path }
 
+let to_secret_name { name; _ } = Storage.Secret_name.inject name
+
 let show { name; _ } = name
 let path { path; _ } = path
 let pp fmt p = Format.fprintf fmt "%s" (show p)

--- a/lib/named_path.ml
+++ b/lib/named_path.ml
@@ -1,0 +1,14 @@
+type t = {
+  name : string;
+  path : Path.t;
+}
+
+let root = { name = "."; path = Path.root }
+
+let of_string name = { name; path = Path.build_rel_path name }
+let of_secret_name secret_name = Storage.Secret_name.project secret_name |> of_string
+let of_path path = { name = Path.project path; path }
+
+let show { name; _ } = name
+let path { path; _ } = path
+let pp fmt p = Format.fprintf fmt "%s" (show p)

--- a/lib/path.ml
+++ b/lib/path.ml
@@ -16,6 +16,8 @@ let dirname p = Filename.dirname (project p) |> inject
 
 let concat p1 p2 = inject (Filename.concat (project p1) (project p2))
 
+let root = inject "."
+
 let is_dot p = project p = "."
 
 let ensure_parent p =
@@ -32,7 +34,7 @@ let build_rel_path rel_path =
   in
   (* normalized "/." is "/" so that removing the prefix results in no path, so don't append in that case: *)
   match normalized with
-  | None -> inject "."
+  | None -> root
   | Some p -> inject @@ Fpath.to_string p
 
 let abs path = concat (inject (Lazy.force !Config.secrets_dir)) (build_rel_path (project path))

--- a/lib/path.mli
+++ b/lib/path.mli
@@ -17,3 +17,6 @@ val ensure_parent : t -> t
 val build_rel_path : string -> t
 val abs : t -> t
 val folder_of_path : t -> t
+
+(** The root path is the secrets dir. *)
+val root : t

--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -145,22 +145,20 @@ module Secrets = struct
 
   let recipient_of_name name = { Age.name; keys = Keys.keys_of_recipient name }
 
-  let recipients_of_group_name_exn ~map_fn group_name' =
-    let recipients_names =
-      match group_name' with
-      | "@everyone" -> Keys.all_recipient_names ()
-      | _ ->
-        (* get the name of the group without the '@' at the beginnning *)
-        let group_name = String.sub group_name' 1 (String.length group_name' - 1) in
-        let existing_groups = all_groups_names () in
-        (match List.mem group_name existing_groups with
-        (* We don't want to allow referencing non existent groups *)
-        | false -> Exn.die "E: group %S doesn't exist" group_name'
-        | true ->
-          let group_file = FilePath.concat (Keys.get_keys_dir ()) (FilePath.add_extension group_name groups_ext) in
-          config_lines group_file)
-    in
-    List.map map_fn recipients_names
+  let expand_group_exn = function
+    | "@everyone" -> Keys.all_recipient_names ()
+    | group_name_at ->
+      (* get the name of the group without the '@' at the beginnning *)
+      let group_name = String.sub group_name_at 1 (String.length group_name_at - 1) in
+      let existing_groups = all_groups_names () in
+      (match List.mem group_name existing_groups with
+      (* We don't want to allow referencing non existent groups *)
+      | false -> Exn.die "E: group %S doesn't exist" group_name_at
+      | true ->
+        let group_file = FilePath.concat (Keys.get_keys_dir ()) (FilePath.add_extension group_name groups_ext) in
+        config_lines group_file)
+
+  let recipients_of_group_name_exn group_name = expand_group_exn group_name |> List.map recipient_of_name
 
   (** Scans a directory and returns a list of secret names and subdirectories *)
   let scan_dir dir =
@@ -180,9 +178,7 @@ module Secrets = struct
     let raw_entries = config_lines keys_file in
     let groups_names, direct_names = List.partition Age.is_group_recipient raw_entries in
     let has_everyone = List.mem "@everyone" groups_names in
-    let group_member_names =
-      List.concat_map (fun group -> try recipients_of_group_name_exn ~map_fn:Fun.id group with _ -> []) groups_names
-    in
+    let group_member_names = List.concat_map (fun group -> try expand_group_exn group with _ -> []) groups_names in
     let expanded = List.sort_uniq String.compare (direct_names @ group_member_names) in
     raw_entries, has_everyone, expanded
 
@@ -236,10 +232,7 @@ module Secrets = struct
   let get_recipients_from_path_exn path =
     let recipients' = get_recipients_names path in
     let groups_names, recipients_names = List.partition Age.is_group_recipient recipients' in
-    let groups_recipients =
-      List.map (fun g -> try recipients_of_group_name_exn ~map_fn:recipient_of_name g with _ -> []) groups_names
-      |> List.flatten
-    in
+    let groups_recipients = List.concat_map (fun g -> try recipients_of_group_name_exn g with _ -> []) groups_names in
     let recipients = List.map recipient_of_name recipients_names in
     let sorted = recipients @ groups_recipients |> List.sort Age.recipient_compare in
     List.fold_right

--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -91,6 +91,9 @@ module Secrets = struct
 
   let to_path secret = secret |> Secret_name.norm_secret |> Secret_name.project |> Path.inject
 
+  (* A secret name is valid if it supports an .age extension -- i.e., it's not root, it doesn't end with ../ *)
+  let valid_name name = Fpath.(v name |> normalize |> basename <> "")
+
   let agefile_of_name name = Path.inject (FilePath.add_extension (Secret_name.project name) ext)
 
   let name_of_file file =
@@ -105,12 +108,7 @@ module Secrets = struct
     try FilePath.add_extension Path.(project @@ abs path) ext |> Sys.file_exists with FilePath.NoExtension _ -> false
 
   let build_secret_name name =
-    try
-      let name = Secret_name.inject name in
-      (* We have this check here to avoid uncaught exns in other spots later *)
-      let (_ : Path.t) = agefile_of_name name in
-      name |> Secret_name.norm_secret
-    with FilePath.NoExtension filename -> Exn.die "%s is not a valid secret" filename
+    if valid_name name then Secret_name.(inject name |> norm_secret) else Exn.die "%s is not a valid secret" name
 
   let get_secrets_tree path =
     let full_path = Path.(project @@ abs path) in

--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -110,6 +110,7 @@ module Secrets = struct
   let build_secret_name name =
     if valid_name name then Secret_name.(inject name |> norm_secret) else Exn.die "%s is not a valid secret" name
 
+  (* True if [path] contains at least one secret, recursively. *)
   let get_secrets_tree path =
     let full_path = Path.(project @@ abs path) in
     FileUtil.find ~follow:Follow (Has_extension ext) full_path (fun accum f -> f :: accum) []

--- a/lib/storage.mli
+++ b/lib/storage.mli
@@ -54,7 +54,8 @@ module Secrets : sig
   val no_keys_file : Path.t -> bool
   val all_groups_names : unit -> string list
   val recipient_of_name : string -> Age.recipient
-  val recipients_of_group_name_exn : map_fn:(string -> 'a) -> string -> 'a list
+  val expand_group_exn : string -> string list
+  val recipients_of_group_name_exn : string -> Age.recipient list
   val get_secrets_for_recipient : string -> Secret_name.t list
   val all_recipient_secrets : unit -> (string, Secret_name.t list) Hashtbl.t
   val get_recipients_file_path : Path.t -> Path.t

--- a/tests/add_who_command.t
+++ b/tests/add_who_command.t
@@ -60,6 +60,10 @@ Should succeed - no changes when adding existing recipients
   $ passage add-who 02/secret1 bobby.bob poppy.pop
   I: no changes made - all specified recipients are already present
 
+Should succeed - add secrets to root
+  $ PASSAGE_IDENTITY=bobby.bob.key passage add-who . poppy.pop
+  I: added 1 recipient
+
 Should fail - add non-existent recipient
   $ passage add-who 02/secret1 nonexistent.user
   Invalid recipient: nonexistent.user does not exist

--- a/tests/rm_who_command.t
+++ b/tests/rm_who_command.t
@@ -72,6 +72,11 @@ Should succeed - warn about some non-existent recipients but remove others
   bobby.bob
   robby.rob
 
+Should succeed - remove secrets from root
+  $ PASSAGE_IDENTITY=bobby.bob.key passage rm-who . dobby.dob
+  I: removed 1 recipient
+
+
 Should fail - remove all recipients from a secret
   $ passage who 02/secret1
   bobby.bob

--- a/tests/who_command.t
+++ b/tests/who_command.t
@@ -28,7 +28,7 @@ Should succeed - passing specific secret with .keys file in dir
 
 Should fail with non_existent path
   $ passage who non_existent_path
-  E: no such secret non_existent_path
+  E: no such secret: non_existent_path
   [1]
 
 Should succeed - valid secret path that ends with ..


### PR DESCRIPTION
# What

Changes the interface such that the commands `who, edit-who, add-who, rm-who` can all act on the same set of paths. 