### PR TITLE
Add OCaml 5.4 support and update compiler versions

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,7 +11,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - "4.14.0"
+          - "4.14.x"
+          - "5.4.x"
 
     runs-on: ${{ matrix.os }}
 
@@ -42,7 +43,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.14
+          ocaml-compiler: "5.4.x"
 
       - name: Lint fmt
         uses: ocaml/setup-ocaml/lint-fmt@v3


### PR DESCRIPTION
- Test against both OCaml 4.14 and 5.4
- Use version ranges (4.14.x, 5.4.x) for flexibility
- Update linting to use OCaml 5.4