### PR TITLE
Upload prebuilt macos binary to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Upload release binary
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  upload-binary:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout tree
+      uses: actions/checkout@v4
+
+    - name: Set-up OCaml
+      uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: "5.4.x"
+
+    - name: Install OCaml deps
+      run: opam install . --deps-only
+
+    - name: Build release binary
+      run: opam exec -- dune build --profile release bin/main.exe
+
+    - name: Upload binary to release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        tag="${{ github.event.release.tag_name }}"
+        asset="passage-${tag}-macos-arm64"
+        cp _build/default/bin/main.exe "$asset"
+        gh release upload "$tag" "$asset" --clobber


### PR DESCRIPTION
## Why

GitHub Releases currently only carry the source tarball produced by `dune-release` (`passage-<tag>.tbz`). Anyone who wants a prebuilt macos `passage` binary has to compile it themselves.

## What

Adds `.github/workflows/release.yml`, triggered on `release: published`:

- Builds on `macos-latest` (arm64) with OCaml 5.4.x using `--profile release`.
- Copies `_build/default/bin/main.exe` to `passage-<tag>-macos-arm64` and uploads it to the release via `gh release upload --clobber` (idempotent on re-runs).
- Uses `permissions: contents: write` so the default `GITHUB_TOKEN` can attach the asset.

Triggering on `release: published` (rather than the raw tag push) avoids racing with `dune-release` creating the release.

## Notes / caveats

- The binary is dynamically linked and still shells out to `age` at runtime, so it's a convenience download, not a fully standalone static binary.
- Only macOS arm64 for now. Linux x86_64 / Intel mac targets can be added later via a matrix if wanted.
- Can't be exercised by this PR since only the `release` event triggers it. To smoke-test before a real release, temporarily add `workflow_dispatch`, or verify on the next `dune-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)